### PR TITLE
refactor: migração para sintaxe de módulo ES e atualização da versão …

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,19 +1,19 @@
-var createError = require("http-errors");
-var express = require('express');
-var path = require('path');
-var cookieParser = require('cookie-parser');
-var logger = require('morgan');
+import createError from 'http-errors';
+import express from 'express';
+import path from 'path';
+import cookieParser from 'cookie-parser';
+import logger from 'morgan';
 
-var indexRouter = require('./routes/index');
-var usersRouter = require('./routes/users');
+import indexRouter from './routes/index.js';
+import usersRouter from './routes/users.js';
 
-var app = express();
+const app = express();
 
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(process.cwd(), 'public')));
 
 app.use('/', indexRouter);
 app.use('/users', usersRouter);
@@ -29,4 +29,4 @@ app.use(function (err, req, res, next) {
     res.render("error");
 });
 
-module.exports = app;
+export default app;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "recicleaqui-20-back",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "start": "node ./bin/www",
     "dev": "nodemon ./bin/www"

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,9 +1,9 @@
-var express = require('express');
-var router = express.Router();
+import express from 'express';
+const router = express.Router();
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
   res.render('index', { title: 'Express' });
 });
 
-module.exports = router;
+export default router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,9 +1,9 @@
-var express = require('express');
-var router = express.Router();
+import express from 'express';
+const router = express.Router();
 
 /* GET users listing. */
 router.get('/', function(req, res, next) {
   res.send('respond with a resource');
 });
 
-module.exports = router;
+export default router;


### PR DESCRIPTION
…do pacote
Esta pull request atualiza o projeto para usar módulos ES em vez de CommonJS, modernizando a base de código e melhorando a compatibilidade com os recursos mais recentes do Node.js. Ele também atualiza a versão e a configuração do projeto para refletir essas alterações.

**Migração para módulos ES:**
* Converter todos os `require` e `module.exports` statements para `import` e `export default` em `app.js`, `routes/index.js`, e `routes/users.js` para a conformidade com o módulo de ES [1](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL1-R16) [2](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL32-R32) [3](diffhunk://#diff-103b73514ced7155e7e33849be2ab49fcbf55e6ff018e0e5356a82d74e6c7e09L1-R9) [4](diffhunk://#diff-fc074c6d7465bef95caefa94a2b0a18d5810e2204cc399dc4dd9d7a646b13affL1-R9)
* Caminhos de importação atualizados para incluir extensões .js conforme exigido pelos módulos ES.

**Atualizações de configuração do projeto:**

* Adicionado `"type": "module"` para `package.json` para habilitar o suporte a módulo ES.
* Versão do projeto `2.0.0` em `package.json` para indicar uma mudança drástica.

**Outras melhorias:**

* Alterado `path.join(__dirname, 'public')` para `path.join(process.cwd(), 'public')` em `app.js` para garantir a compatibilidade com os módulos ES, como `__dirname` não está disponível.