### PR TITLE
refactor: migração para sintaxe de módulo ES

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -4,22 +4,24 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('recicleaqui-20-back:server');
-var http = require('http');
+import app from '../app.js';
+import debugLib from 'debug';
+import http from 'http';
+
+const debug = debugLib('recicleaqui-20-back:server');
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+const port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 /**
  * Create HTTP server.
  */
 
-var server = http.createServer(app);
+const server = http.createServer(app);
 
 /**
  * Listen on provided port, on all network interfaces.
@@ -34,7 +36,7 @@ server.on('listening', onListening);
  */
 
 function normalizePort(val) {
-  var port = parseInt(val, 10);
+  const port = parseInt(val, 10);
 
   if (isNaN(port)) {
     // named pipe
@@ -58,7 +60,7 @@ function onError(error) {
     throw error;
   }
 
-  var bind = typeof port === 'string'
+  const bind = typeof port === 'string'
     ? 'Pipe ' + port
     : 'Port ' + port;
 
@@ -82,8 +84,8 @@ function onError(error) {
  */
 
 function onListening() {
-  var addr = server.address();
-  var bind = typeof addr === 'string'
+  const addr = server.address();
+  const bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
   debug('Listening on ' + bind);


### PR DESCRIPTION
**Migração para módulos ES:**

* Converter todos os comandos `require` e `module.exports` para `import` e `export default` em `bin/www.js` para a conformidade com o módulo de ES [[1]](diffhunk://#diff-65dad2b6727f42c695dacd56f58230cf9b8c0b86b1c8d5aa9a50cdd4996869b7)
* Caminhos de importação atualizados para incluir extensões .js conforme exigido pelos módulos ES.

**Outras melhorias:**

* Alterada declaração de variáveis para constantes